### PR TITLE
fix: make Modal container overflow visible for small Modal Dialog usecase

### DIFF
--- a/lib/components/Modal/index.js
+++ b/lib/components/Modal/index.js
@@ -42,6 +42,7 @@ const Container = styled.div`
   border-radius: ${variables.borderRadius};
   max-height: 90vh;
   overflow-y: auto;
+  ${props => (props.overflowVisible ? "overflow: visible" : "")}
 `;
 
 const Actions = styled.div`
@@ -136,12 +137,17 @@ class Modal extends React.Component {
       visible,
       onConfirm,
       onCancel,
-      isDisplayFooter = true
+      isDisplayFooter = true,
+      overflowVisible = false
     } = this.props;
 
     return (
       <Overlay visible={visible}>
-        <Container width={width} height={height}>
+        <Container
+          width={width}
+          height={height}
+          overflowVisible={overflowVisible}
+        >
           <Content>{children}</Content>
           {isDisplayFooter && (
             <Actions>
@@ -184,7 +190,9 @@ Modal.propTypes = {
   /** Specifies the button disabled state */
   disabledCancel: PropTypes.bool,
   /** Specifies whether to hide the foot or not. Default: true - Show footer*/
-  isDisplayFooter: PropTypes.bool
+  isDisplayFooter: PropTypes.bool,
+  /** Specifies whether the Dialogue overflow is visible or not - Default: false. If height is not enough, verticle scroll bar will be displayed (overflow-y: auto) */
+  overflowVisible: PropTypes.bool
 };
 
 /** @component */


### PR DESCRIPTION

<img width="575" alt="afterChange" src="https://user-images.githubusercontent.com/55069683/67908308-35261100-fbcf-11e9-8b9b-aededb4b502e.png">
<img width="467" alt="beforeChange" src="https://user-images.githubusercontent.com/55069683/67908357-58e95700-fbcf-11e9-911d-89cf21d4f34b.png">

## What it does, and why

> Add a thorough explanation of what the code in this PR does in this section. Make sure to also cover why your changes are necessary and useful.

When the Modal height is too small, the vertical scroll bar will be displayed.
But it's hard to use when there is another scrollable area inside the Modal.
Change container to overflow visible, so that we only display one scroll bar for the inner content,
not on the Modal.

> Is there anything not straightforward in the code? Explain it. If you choose to use a pattern rather than another, use this space to provide the reason for your choice.

No.

## Checklist

> Please go through following checklist before requesting review and fix issues listed there. If your code touches the files with the below in question, please address them.

#### Coding conventions

- [x] Have you split out components if there more than one React class or component in this file?
- [x] Have you converted the React class component to functional component?
- [x] Are you using spread props for the React component? If so, please state the exact properties required for the component `<Component prop1={val1} prop2={val2} />`
- [x] Are you doing prop drilling, going further than 2 levels deep? If so, refer to this document: https://blog.axlight.com/posts/four-patterns-for-global-state-with-react-hooks-context-or-redux/
- [x] If you're doing loops, are you using Lodash over es6 methods?
- [x] Have you extracted inline CSS in JSX out into its own styled variable?
- [x] Have you written PropTypes for the components?
- [xhttps://www.scmp.com/news/asia/east-asia/article/3035649/fire-engulfs-japans-600-year-old-shuri-castle-world-heritage] Are you using hooks instead of HOC where possible?

#### Workflow

- [ ] Are you writing documentation for the bits of code with complex changes?
- [ ] Are you writing unit tests for business logic?
- [ ] Are Stories are written for every visual change?
- [ ] Request review if it is any visual/interaction

## Testing

> Explain how to test the changes in detail.
>
> - What testing have you performed on this change?
> - Is it unit tested? If not, why?
> - What manual steps have you performed to ensure its functioning correctly when integrated?

## Trello Tickets

> If this PR implements changes related to one or more Trello tickets please add them here:

## UI Changes

> If this PR introduce some interaction or animation change please also add GIF with how it behaves. Don't forget that this change should be possible to simulate in storybook.
> You can use [this tool](http://gifbrewery.com/) to record your screen and convert it to a GIF.
