### PR TITLE
Fixes to Avatar and Typography to use themeGet. Added px to systemtheme.

### DIFF
--- a/packages/orcs-design-system/lib/Typography.stories.mdx
+++ b/packages/orcs-design-system/lib/Typography.stories.mdx
@@ -1,7 +1,7 @@
 import { ThemeProvider } from "styled-components";
 import systemtheme from "../lib/systemtheme";
 import { Meta, Typeset, Preview, Story } from "@storybook/addon-docs/blocks";
-import { H1, H2, H3, H4, H5, H6, P, Text, Quote, Code } from "./components/Typography";
+import { H1, H2, H3, H4, H5, H6, P, Text, Quote, Small, Code } from "./components/Typography";
 import Box from "./components/Box";
 
 <Meta title="System/Typography" />
@@ -15,7 +15,7 @@ import Box from "./components/Box";
 The typography system requires you to import each subcomponent you want to use, for example:
 
 ```
-import { H1, H2, H3, H4, H5, H6, P, Em, Code, Caption } from "orca-design-system";
+import { H1, H2, H3, H4, H5, H6, P, Text, Quote, Small, Code } from "orcs-design-system";
 ```
 
 ## Font families
@@ -85,7 +85,7 @@ To render text in a `span` HTML element without the paragraph formatting, use th
 
 ### Size and emphasis
 
-To render type smaller or larger, use `sizing="small"` or `sizing="large"`, or if needed (for example if you are already using a variant) you can use `fontSize` property as demonstrated below. Unless it is for a very specific purpose, strongly recommend minimising the resizing of text and simply using the appropriate type element the next size up (or down) on the design system scale.
+To render type smaller or larger, use `sizing="small"` or `sizing="large"` on a heading, or if needed you can use `fontSize` property or the `Small` element as demonstrated below. Unless it is for a very specific purpose, strongly recommend minimising the resizing of text and simply using the appropriate type element the next size up (or down) on the design system scale.
 
 <Preview>
 <Story name="Styling/Sizing">
@@ -93,7 +93,8 @@ To render type smaller or larger, use `sizing="small"` or `sizing="large"`, or i
 <H5 sizing="small">Small variant of H5</H5>
 <H5 sizing="large">Large variant of H5</H5>
 <H5 fontSize={2}>Even smaller H5, scaled down two steps in the fontSize array</H5>
-<Text fontSize="10px">Very small text using a specific fontSize value</Text>
+<P fontSize="10px">Very small text using a specific fontSize value</P>
+<Small>Small text using the Small component</Small>
 </>
 </Story>
 </Preview>

--- a/packages/orcs-design-system/lib/Typography.stories.mdx
+++ b/packages/orcs-design-system/lib/Typography.stories.mdx
@@ -1,7 +1,7 @@
 import { ThemeProvider } from "styled-components";
-import * as systemtheme from "../lib/systemtheme";
+import systemtheme from "../lib/systemtheme";
 import { Meta, Typeset, Preview, Story } from "@storybook/addon-docs/blocks";
-import { H1, H2, H3, H4, H5, H6, P, Text, Strong, Quote, Code } from "./components/Typography";
+import { H1, H2, H3, H4, H5, H6, P, Text, Quote, Code } from "./components/Typography";
 import Box from "./components/Box";
 
 <Meta title="System/Typography" />
@@ -15,7 +15,7 @@ import Box from "./components/Box";
 The typography system requires you to import each subcomponent you want to use, for example:
 
 ```
-import { H1, H2, H3, H4, H5, H6, P, Em, Strong, Code, Caption } from "orca-design-system";
+import { H1, H2, H3, H4, H5, H6, P, Em, Code, Caption } from "orca-design-system";
 ```
 
 ## Font families
@@ -67,6 +67,8 @@ These use `<H1>` to `<H6>` tags. For semantic and accessibility usage guidelines
 <P>Regular paragraph text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed aliquet at elit sit amet iaculis. Cras eget sapien et ligula mollis placerat non venenatis dolor. Fusce id mi risus. Ut sit amet diam in dui maximus sagittis a at dolor. Cras volutpat est nec arcu interdum pulvinar in vitae erat.</P>
 <P textAlign="center">Centered paragraph text.</P>
 <P textAlign="right">Right-aligned paragraph text.</P>
+<P weight="light">Light paragraph text</P>
+<P sizing="small">Small paragraph text</P>
 </>
 </Story>
 </Preview>
@@ -83,24 +85,28 @@ To render text in a `span` HTML element without the paragraph formatting, use th
 
 ### Size and emphasis
 
-To render type smaller or larger, use `size="small"` or `size="large"`, or if needed (for example if you are already using a variant) you can use `fontSize` property as demonstrated below. Unless it is for a very specific purpose, strongly recommend minimising the resizing of text and simply using the appropriate type element the next size up (or down) on the design system scale.
+To render type smaller or larger, use `sizing="small"` or `sizing="large"`, or if needed (for example if you are already using a variant) you can use `fontSize` property as demonstrated below. Unless it is for a very specific purpose, strongly recommend minimising the resizing of text and simply using the appropriate type element the next size up (or down) on the design system scale.
 
 <Preview>
 <Story name="Styling/Sizing">
 <>
-<H5 size="small">Small variant of H5</H5>
-<H5 size="large">Large variant of H5</H5>
-<H3 fontSize={4}>Smaller H3, scaled down two steps in the fontSize array</H3>
+<H5 sizing="small">Small variant of H5</H5>
+<H5 sizing="large">Large variant of H5</H5>
+<H5 fontSize={2}>Even smaller H5, scaled down two steps in the fontSize array</H5>
 <Text fontSize="10px">Very small text using a specific fontSize value</Text>
 </>
 </Story>
 </Preview>
 
-To render type with emphasis, use `weight="bold"` or wrap the type in a `<Strong>` tag.
+To render type with emphasis, use `weight="bold"` or wrap the type in a `<strong>` tag.
 
 <Preview>
+<Story name="Styling/Emphasis">
+<>
 <P weight="bold">Bold paragraph text lorem ipsum dolor sit amet</P>
-<P>Only <Strong>partially bolded</Strong> paragraph</P>
+<P>Only <strong>partially bolded</strong> paragraph</P>
+</>
+</Story>
 </Preview>
 
 ### Colours
@@ -116,7 +122,7 @@ To apply colour to text, use the `color` property in the `Text` component. Usage
 <br />
 <Text color="danger">Danger-coloured text</Text>
 <br />
-<Box bg="greyDark">
+<Box bg="greyDarker">
 <Text color="white">White text for dark backgrounds</Text>
 </Box>
 </>
@@ -126,9 +132,13 @@ To apply colour to text, use the `color` property in the `Text` component. Usage
 ## Miscellaneous
 
 <Preview>
+<Story name="Miscellaneous/Blockquote">
 <Quote>"Used to display block quotes lorem ipsum dolor sit amet" <em> - Adam, 2018</em></Quote>
+</Story>
 </Preview>
 
 <Preview>
+<Story name="Miscellaneous/Code">
 <Code>&lt;html&gt; &lt;head&gt; &lt;body&gt; Hello I am a code block &lt;/body&gt; &lt;/head&gt; &lt;/html&gt;</Code>
+</Story>
 </Preview>

--- a/packages/orcs-design-system/lib/components/Avatar/Avatar.stories.mdx
+++ b/packages/orcs-design-system/lib/components/Avatar/Avatar.stories.mdx
@@ -97,27 +97,27 @@ For when Avatar is used on a dark background
     <Box bg="greyDark">
     <Spacer>
     <Avatar
-      color="white"
+      type="inverted"
       title="Ayden Lundgre"
       subtitle="Senior Business Analyst"
       initials="AL"
       image="https://s3.amazonaws.com/uifaces/faces/twitter/jsa/128.jpg"
     />
     <Avatar
-      color="white"
+      type="inverted"
       title="Ayden Lundgre"
       subtitle="Senior Business Analyst"
       initials="AL"
       />
     <Avatar
-      color="white"
+      type="inverted"
       title={<StyledLink href="#">Ayden Lundgre</StyledLink>}
       subtitle="Senior Business Analyst"
       initials="AL"
       image="https://s3.amazonaws.com/uifaces/faces/twitter/jsa/128.jpg"
     />
     <Avatar
-      color="white"
+      type="inverted"
       sizing="small"
       title="Ayden Lundgre"
       subtitle="Senior Business Analyst"
@@ -125,7 +125,7 @@ For when Avatar is used on a dark background
       image="https://s3.amazonaws.com/uifaces/faces/twitter/jsa/128.jpg"
     />
     <Avatar
-      color="white"
+      type="inverted"
       sizing="small"
       title={<StyledLink href="#">Ayden Lundgre</StyledLink>}
       subtitle="Senior Business Analyst"
@@ -139,12 +139,10 @@ For when Avatar is used on a dark background
 
 ## Properties
 
-You can use `space` and `layout` Styled-System properties with `Avatar`, as well as two custom props: `sizing` and `color`.
+You can use two custom props: `sizing` and `type`.
 
 ### For reference, see:
 
-- [space on Styled-System](https://styled-system.com/table#space)
-- [layout on Styled-System](https://styled-system.com/table#layout)
 - [systemtheme.js](https://github.com/orchestrated-io/orca-design-system/blob/master/packages/orcs-design-system/lib/systemtheme.js) (our arrays for design system values)
 
 By default, we've set certain values on `Avatar` properties as documented in the table below. If these properties are not specified they will take on the default values.

--- a/packages/orcs-design-system/lib/components/Avatar/Avatar.stories.mdx
+++ b/packages/orcs-design-system/lib/components/Avatar/Avatar.stories.mdx
@@ -94,7 +94,7 @@ For when Avatar is used on a dark background
 
 <Preview>
 <Story name="Inverted">
-    <Box bg="greyDark">
+    <Box bg="greyDarker">
     <Spacer>
     <Avatar
       type="inverted"

--- a/packages/orcs-design-system/lib/components/Avatar/index.js
+++ b/packages/orcs-design-system/lib/components/Avatar/index.js
@@ -3,15 +3,18 @@ import styled from "styled-components";
 import { space, layout, variant } from "styled-system";
 import PropTypes from "prop-types";
 import { H3, Text } from "../Typography";
-import * as systemtheme from "../../systemtheme";
+import css from "@styled-system/css";
+import themeGet from "@styled-system/theme-get";
 
-const AvatarWrapper = styled.div`
-  ${space}
-  ${layout}
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
-  ${variant({
+const AvatarWrapper = styled("div")(
+  layout,
+  space,
+  css({
+    boxSizing: "border-box",
+    display: "flex",
+    alignItems: "center"
+  }),
+  variant({
     prop: "sizing",
     variants: {
       small: {
@@ -19,146 +22,166 @@ const AvatarWrapper = styled.div`
       },
       default: {}
     }
-  })}
-`;
+  }),
+  variant({
+    prop: "type",
+    variants: {
+      inverted: {
+        color: "white"
+      }
+    }
+  })
+);
 
-const TextContent = styled.div`
-  > * + * {
-    margin-top: ${systemtheme.space[2]}px;
-  }
-  margin-left: ${systemtheme.space[3]}px;
-  ${variant({
+const TextContent = styled("div")(
+  props => ({
+    marginLeft: themeGet("space.3")(props)
+  }),
+  variant({
+    prop: "sizing",
+    variants: {
+      small: {
+        fontSize: 1
+      }
+    }
+  }),
+  variant({
+    prop: "type",
+    variants: {
+      inverted: {
+        color: "white"
+      }
+    }
+  })
+);
+
+const Image = styled("img")(
+  props => ({
+    width: "calc(" + themeGet("space.5")(props) + " * 2)",
+    height: "calc(" + themeGet("space.5")(props) + " * 2)"
+  }),
+  css({
+    backgroundColor: "greyLighter",
+    border: "0",
+    display: "block",
+    borderRadius: "50%"
+  }),
+  props =>
+    variant({
+      prop: "sizing",
+      variants: {
+        small: {
+          width: "calc(" + themeGet("space.4")(props) + " * 2.25)",
+          height: "calc(" + themeGet("space.4")(props) + " * 2.25)"
+        }
+      }
+    })
+);
+
+const Circle = styled("div")(
+  props => ({
+    width: "calc(" + themeGet("space.5")(props) + " * 2)",
+    height: "calc(" + themeGet("space.5")(props) + " * 2)",
+    fontWeight: themeGet("fontWeights.2")(props)
+  }),
+  css({
+    backgroundColor: "greyLighter",
+    border: "0",
+    display: "flex",
+    borderRadius: "50%",
+    alignItems: "center",
+    justifyContent: "center",
+    textAlign: "center",
+    textTransform: "uppercase"
+  }),
+  props =>
+    variant({
+      prop: "sizing",
+      variants: {
+        small: {
+          width: "calc(" + themeGet("space.4")(props) + " * 2.25)",
+          height: "calc(" + themeGet("space.4")(props) + " * 2.25)"
+        }
+      }
+    }),
+  variant({
+    prop: "type",
+    variants: {
+      inverted: {
+        backgroundColor: "greyDarker",
+        color: "white"
+      }
+    }
+  })
+);
+
+const Title = styled(H3)(
+  variant({
+    prop: "sizing",
+    variants: {
+      small: {
+        fontSize: 2
+      }
+    }
+  }),
+  variant({
+    prop: "type",
+    variants: {
+      inverted: {
+        color: "white"
+      }
+    }
+  })
+);
+
+const Subtitle = styled(Text)(
+  css({
+    color: "grey"
+  }),
+  variant({
     prop: "sizing",
     variants: {
       small: {
         fontSize: 1,
-        marginLeft: `${systemtheme.space[3]}px`
-      },
-      default: {}
+        fontWeight: 0
+      }
     }
-  })}
-`;
-
-const Image = styled.img`
-  background-color: ${systemtheme.colors.greyLighter};
-  border-radius: 50%;
-  border: 0;
-  display: block;
-  width: calc(${systemtheme.space[5]}px * 2);
-  height: calc(${systemtheme.space[5]}px * 2);
-  ${variant({
-    prop: "sizing",
+  }),
+  variant({
+    prop: "type",
     variants: {
-      small: {
-        height: "calc(" + systemtheme.space[4] + "px * 2.25)",
-        width: "calc(" + systemtheme.space[4] + "px * 2.25)"
+      inverted: {
+        color: "white"
       },
       default: {}
     }
-  })}
-`;
-
-const Circle = styled.div`
-  border-radius: 50%;
-  background-color: ${systemtheme.colors.greyLighter};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  text-transform: uppercase;
-  font-weight: ${systemtheme.fontWeights[2]};
-  width: calc(${systemtheme.space[5]}px * 2);
-  height: calc(${systemtheme.space[5]}px * 2);
-  ${variant({
-    prop: "sizing",
-    variants: {
-      small: {
-        height: "calc(" + systemtheme.space[4] + "px * 2.25)",
-        width: "calc(" + systemtheme.space[4] + "px * 2.25)"
-      },
-      default: {}
-    }
-  })}
-  ${variant({
-    prop: "color",
-    variants: {
-      white: {
-        backgroundColor: systemtheme.colors.greyDark,
-        color: systemtheme.colors.white
-      },
-      default: {}
-    }
-  })}
-`;
-
-const Title = styled(H3)`
-  ${variant({
-    prop: "sizing",
-    variants: {
-      small: {
-        fontSize: systemtheme.fontSizes[2]
-      },
-      default: {}
-    }
-  })}
-  ${variant({
-    prop: "color",
-    variants: {
-      white: {
-        color: systemtheme.colors.white
-      },
-      default: {}
-    }
-  })}
-`;
-
-const Subtitle = styled(Text)`
-  color: ${systemtheme.colors.grey};
-  ${variant({
-    prop: "sizing",
-    variants: {
-      small: {
-        fontSize: systemtheme.fontSizes[1],
-        fontWeight: systemtheme.fontWeights[0]
-      },
-      default: {}
-    }
-  })}
-  ${variant({
-    prop: "color",
-    variants: {
-      white: {
-        color: systemtheme.colors.white
-      },
-      default: {}
-    }
-  })}
-`;
+  })
+);
 
 const Avatar = ({
-  color,
   sizing,
   image,
   initials,
   title,
   subtitle,
+  type,
   ...props
 }) => {
   return (
-    <AvatarWrapper {...props} sizing={sizing}>
+    <AvatarWrapper {...props} type={type} sizing={sizing}>
       {image ? (
         <Image src={image} sizing={sizing} />
       ) : (
-        <Circle color={color} sizing={sizing}>
+        <Circle sizing={sizing} type={type}>
           {initials}
         </Circle>
       )}
-      <TextContent sizing={sizing}>
-        <Title color={color} sizing={sizing}>
+      <TextContent type={type} sizing={sizing}>
+        <Title type={type} sizing={sizing}>
           {title}
         </Title>
         {subtitle ? (
-          <Subtitle color={color} sizing={sizing}>
+          <Subtitle type={type} sizing={sizing}>
             {subtitle}
           </Subtitle>
         ) : null}
@@ -170,8 +193,8 @@ const Avatar = ({
 Avatar.propTypes = {
   /** Changes the sizing of the Avatar component */
   sizing: PropTypes.oneOf(["small", "default"]),
-  /** Changes the text colour; use `color="white"` for dark backgrounds */
-  color: PropTypes.oneOf(["white", "default"]),
+  /** Specifies the inverted type for dark backgrounds */
+  type: PropTypes.oneOf(["inverted", "default"]),
   /** Specifies a source path for an image */
   image: PropTypes.string,
   /** Specifies initials of person if available */
@@ -180,6 +203,11 @@ Avatar.propTypes = {
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** Specifies subtitle / role */
   subtitle: PropTypes.string
+};
+
+Avatar.defaultProps = {
+  sizing: "default",
+  type: "default"
 };
 
 export default Avatar;

--- a/packages/orcs-design-system/lib/components/Typography/index.js
+++ b/packages/orcs-design-system/lib/components/Typography/index.js
@@ -1,238 +1,254 @@
 import styled from "styled-components";
-import { typography, color, space, variant } from "styled-system";
-import * as systemtheme from "../../systemtheme";
-import { rgba } from "polished";
+import { typography, color, variant, compose } from "styled-system";
+import css from "@styled-system/css";
 
-export const H1 = styled.h1`
-  ${typography}
-  ${color}
-  ${variant({
+const typeStyles = compose(typography, color);
+
+export const H1 = styled("h1")(
+  css({
+    fontFamily: "main",
+    fontSize: 6,
+    fontWeight: 1
+  }),
+  variant({
     prop: "weight",
     variants: {
       light: {
-        fontWeight: systemtheme.fontWeights[0]
+        fontWeight: 0
       },
       bold: {
-        fontWeight: systemtheme.fontWeights[2]
+        fontWeight: 2
       }
     }
-  })}
-    ${variant({
-      prop: "size",
-      variants: {
-        small: {
-          fontSize: systemtheme.fontSizes[5]
-        },
-        large: {
-          fontSize: systemtheme.fontSizes[7]
-        }
-      }
-    })}
-`;
-
-export const H2 = styled.h2`
-  ${typography}
-  ${color}
-  ${variant({
-    prop: "weight",
+  }),
+  variant({
+    prop: "sizing",
     variants: {
-      light: {
-        fontWeight: systemtheme.fontWeights[0]
-      },
-      bold: {
-        fontWeight: systemtheme.fontWeights[2]
-      }
-    }
-  })}
-    ${variant({
-      prop: "size",
-      variants: {
-        small: {
-          fontSize: systemtheme.fontSizes[4]
-        },
-        large: {
-          fontSize: systemtheme.fontSizes[6]
-        }
-      }
-    })}
-`;
-
-export const H3 = styled.h3`
-  ${typography}
-  ${color}
-  ${variant({
-    prop: "weight",
-    variants: {
-      light: {
-        fontWeight: systemtheme.fontWeights[0]
-      },
-      bold: {
-        fontWeight: systemtheme.fontWeights[2]
-      }
-    }
-  })}
-    ${variant({
-      prop: "size",
-      variants: {
-        small: {
-          fontSize: systemtheme.fontSizes[3]
-        },
-        large: {
-          fontSize: systemtheme.fontSizes[5]
-        }
-      }
-    })}
-`;
-
-export const H4 = styled.h4`
-  ${typography}
-  ${color}
-  ${variant({
-    prop: "weight",
-    variants: {
-      light: {
-        fontWeight: systemtheme.fontWeights[0]
-      },
-      bold: {
-        fontWeight: systemtheme.fontWeights[2]
-      }
-    }
-  })}
-    ${variant({
-      prop: "size",
-      variants: {
-        small: {
-          fontSize: systemtheme.fontSizes[2]
-        },
-        large: {
-          fontSize: systemtheme.fontSizes[4]
-        }
-      }
-    })}
-`;
-export const H5 = styled.h5`
-  ${typography}
-  ${color}
-  ${variant({
-    prop: "weight",
-    variants: {
-      light: {
-        fontWeight: systemtheme.fontWeights[0]
-      },
-      bold: {
-        fontWeight: systemtheme.fontWeights[2]
-      }
-    }
-  })}
-    ${variant({
-      prop: "size",
-      variants: {
-        small: {
-          fontSize: systemtheme.fontSizes[1]
-        },
-        large: {
-          fontSize: systemtheme.fontSizes[3]
-        }
-      }
-    })}
-`;
-
-export const H6 = styled.h6`
-  ${typography}
-  ${color}
-  ${variant({
-    prop: "weight",
-    variants: {
-      light: {
-        fontWeight: systemtheme.fontWeights[0]
-      },
-      bold: {
-        fontWeight: systemtheme.fontWeights[2]
-      }
-    }
-  })}
-    ${variant({
-      prop: "size",
-      variants: {
-        small: {
-          fontSize: systemtheme.fontSizes[0]
-        },
-        large: {
-          fontSize: systemtheme.fontSizes[2]
-        }
-      }
-    })}
-`;
-
-export const P = styled.p`
-${typography}
-${color}
-${space}
-${variant({
-  prop: "weight",
-  variants: {
-    light: {
-      fontWeight: systemtheme.fontWeights[1]
-    },
-    bold: {
-      fontWeight: systemtheme.fontWeights[2]
-    }
-  }
-})}
-  ${variant({
-    prop: "size",
-    variants: {
-      small: {
-        fontSize: systemtheme.fontSizes[1]
-      },
       large: {
-        fontSize: systemtheme.fontSizes[3]
+        fontSize: 7
+      },
+      small: {
+        fontSize: 5
       }
     }
-  })}
-  line-height: ${systemtheme.lineHeights[1]};
-`;
+  }),
+  typeStyles
+);
 
-export const Text = styled.span`
-  ${typography}
-  ${color}
-`;
+export const H2 = styled("h2")(
+  css({
+    fontFamily: "main",
+    fontSize: 5,
+    fontWeight: 1
+  }),
+  variant({
+    prop: "weight",
+    variants: {
+      light: {
+        fontWeight: 0
+      },
+      bold: {
+        fontWeight: 2
+      }
+    }
+  }),
+  variant({
+    prop: "sizing",
+    variants: {
+      large: {
+        fontSize: 6
+      },
+      small: {
+        fontSize: 4
+      }
+    }
+  }),
+  typeStyles
+);
 
-export const Strong = styled.span`
-  ${typography}
-  font-weight: ${systemtheme.fontWeights[2]};
-`;
+export const H3 = styled("h3")(
+  css({
+    fontFamily: "main",
+    fontSize: 4,
+    fontWeight: 1
+  }),
+  variant({
+    prop: "weight",
+    variants: {
+      light: {
+        fontWeight: 0
+      },
+      bold: {
+        fontWeight: 2
+      }
+    }
+  }),
+  variant({
+    prop: "sizing",
+    variants: {
+      large: {
+        fontSize: 5
+      },
+      small: {
+        fontSize: 3
+      }
+    }
+  }),
+  typeStyles
+);
 
-export const Quote = styled.blockquote`
-  ${typography}
-  display: block;
-  font-size: ${systemtheme.fontSizes[4]}px;
-  line-height: ${systemtheme.lineHeights[1]};
-  border-left: solid ${systemtheme.space[2]}px ${systemtheme.colors.greyDark};
-  padding: ${systemtheme.space[3]}px ${systemtheme.space[4]}px;
-  em {
-    display: block;
-    font-style: italic;
-    font-size: ${systemtheme.fontSizes[3]}px;
-    color: ${systemtheme.colors.grey};
-  }
-`;
+export const H4 = styled("h4")(
+  css({
+    fontFamily: "main",
+    fontSize: 3,
+    fontWeight: 1
+  }),
+  variant({
+    prop: "weight",
+    variants: {
+      light: {
+        fontWeight: 0
+      },
+      bold: {
+        fontWeight: 2
+      }
+    }
+  }),
+  variant({
+    prop: "sizing",
+    variants: {
+      large: {
+        fontSize: 4
+      },
+      small: {
+        fontSize: 2
+      }
+    }
+  }),
+  typeStyles
+);
 
-export const Code = styled.code`
-${typography}
-  line-height: ${systemtheme.lineHeights[1]};
-  background: ${rgba(systemtheme.colors.warningLightest, 0.4)};
-  padding: ${systemtheme.space[3]}px;
-`;
+export const H5 = styled("h5")(
+  css({
+    fontFamily: "main",
+    fontSize: 2,
+    fontWeight: 1
+  }),
+  variant({
+    prop: "weight",
+    variants: {
+      light: {
+        fontWeight: 0
+      },
+      bold: {
+        fontWeight: 2
+      }
+    }
+  }),
+  variant({
+    prop: "sizing",
+    variants: {
+      large: {
+        fontSize: 3
+      },
+      small: {
+        fontSize: 1
+      }
+    }
+  }),
+  typeStyles
+);
 
-export default { H1, H2, H3, H4, H5, H6, P, Text, Strong, Quote, Code };
+export const H6 = styled("h6")(
+  css({
+    fontFamily: "main",
+    fontSize: 1,
+    fontWeight: 1
+  }),
+  variant({
+    prop: "weight",
+    variants: {
+      light: {
+        fontWeight: 0
+      },
+      bold: {
+        fontWeight: 2
+      }
+    }
+  }),
+  variant({
+    prop: "sizing",
+    variants: {
+      large: {
+        fontSize: 2
+      },
+      small: {
+        fontSize: 0
+      }
+    }
+  }),
+  typeStyles
+);
 
-P.defaultProps = {
-  fontSize: systemtheme.fontSizes[2],
-  fontWeight: systemtheme.fontWeights[1]
-};
+export const P = styled("p")(
+  css({
+    fontFamily: "main",
+    fontSize: 2,
+    lineHeight: 1
+  }),
+  variant({
+    prop: "weight",
+    variants: {
+      light: {
+        fontWeight: 0
+      },
+      bold: {
+        fontWeight: 2
+      }
+    }
+  }),
+  variant({
+    prop: "sizing",
+    variants: {
+      large: {
+        fontSize: 3
+      },
+      small: {
+        fontSize: 1
+      }
+    }
+  }),
+  typeStyles
+);
 
-Text.defaultProps = {
-  fontWeight: systemtheme.fontWeights[1],
-  lineHeight: systemtheme.lineHeights[1]
-};
+export const Text = styled("span")(typeStyles);
+
+export const Quote = styled("blockquote")(
+  css({
+    display: "block",
+    fontSize: 4,
+    lineHeight: 1,
+    borderLeftStyle: "solid",
+    borderLeftWidth: 2,
+    borderLeftColor: "greyDark",
+    px: 3,
+    py: 4,
+    em: {
+      display: "block",
+      fontStyle: "italic",
+      fontSize: 3,
+      color: "grey"
+    }
+  })
+);
+
+export const Code = styled("div")(
+  css({
+    padding: 3,
+    lineHeight: 1,
+    fontFamily: "monospace",
+    backgroundColor: "warningLightest"
+  })
+);
+
+export default { H1, H2, H3, H4, H5, H6, P, Text, Quote, Code };

--- a/packages/orcs-design-system/lib/components/Typography/index.js
+++ b/packages/orcs-design-system/lib/components/Typography/index.js
@@ -212,14 +212,13 @@ export const P = styled("p")(
     variants: {
       large: {
         fontSize: 3
-      },
-      small: {
-        fontSize: 1
       }
     }
   }),
   typeStyles
 );
+
+export const Small = styled("small")(typeStyles);
 
 export const Text = styled("span")(typeStyles);
 
@@ -251,4 +250,4 @@ export const Code = styled("div")(
   })
 );
 
-export default { H1, H2, H3, H4, H5, H6, P, Text, Quote, Code };
+export default { H1, H2, H3, H4, H5, H6, P, Text, Quote, Small, Code };

--- a/packages/orcs-design-system/lib/systemtheme.js
+++ b/packages/orcs-design-system/lib/systemtheme.js
@@ -7,25 +7,39 @@ export const fonts = {
 };
 export const font = fonts.main;
 export const fontFamilies = fonts;
-export const fontSizes = [12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 64];
+export const fontSizes = [
+  "12px",
+  "14px",
+  "16px",
+  "18px",
+  "20px",
+  "24px",
+  "28px",
+  "32px",
+  "36px",
+  "48px",
+  "64px"
+];
 export const fontWeights = [300, 400, 600];
 export const lineHeights = [1, 1.5, 2];
 
 // Z-AXIS spec
 export const zIndex = [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
-const spaceScale = [0, 2, 4, 8, 16, 24, 32, 64, 128, 256, 512];
-
-export const space = {
-  ...spaceScale,
-  xxs: spaceScale[1],
-  xs: spaceScale[2],
-  sm: spaceScale[3],
-  md: spaceScale[4],
-  lg: spaceScale[5],
-  xl: spaceScale[6],
-  xxl: spaceScale[7]
-};
+// SPACING
+export const space = [
+  0,
+  "2px",
+  "4px",
+  "8px",
+  "16px",
+  "24px",
+  "32px",
+  "64px",
+  "128px",
+  "256px",
+  "512px"
+];
 
 // BORDERS
 export const radii = [0, 2, 6];
@@ -118,7 +132,6 @@ export const colors = {
 // For browser reset, setting global box sizing and font sizing etc.
 
 export const GlobalStyles = createGlobalStyle`
-
 /* apply a natural box layout model to all elements, but allowing components to change */
 html {
     box-sizing: border-box;
@@ -127,81 +140,64 @@ html {
 *, *:before, *:after {
     box-sizing: inherit;
 }
-
 html,
 body {
     height: 100%;
     width: 100%;
     margin: 0;
 }
-
 /* Import custom fonts */
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i');
-
 body {
     font-family: ${fonts.main};
     color: ${colors.greyDarkest};
 }
-
 /* set rem text size and styling */
 html { font-size: 62.5%; }
 body { font-size: 16px; font-size: 1.6rem; }
-
 main {
   display: flex;
 	align-items: stretch;
 	align-content: stretch;
 	width: 100%;
 }
-
 section {
     height: calc(100vh - 60px);
     width: 100%;
 	overflow-y: scroll;
 }
-
 img {
     border-style: none;
 }
-
 small {
     font-size: 80%;
 }
-
 p {
     margin: 0;
 }
-
 h1, h2, h3, h4, h5, h6 {
   font-weight: ${fontWeights[1]};
   font-family: ${fonts.main};
   margin: 0;
 }
-
 h1 {
   font-size: ${fontSizes[6]}px
 }
-
 h2 {
   font-size: ${fontSizes[5]}px
 }
-
 h3 {
   font-size: ${fontSizes[4]}px
 }
-
 h4 {
   font-size: ${fontSizes[3]}px
 }
-
 h5 {
   font-size: ${fontSizes[2]}px
 }
-
 h6 {
   font-size: ${fontSizes[1]}px
 }
-
 /* Animations */
 @keyframes checkboxOn {
   0% {
@@ -243,7 +239,6 @@ h6 {
       20px -12px 0 11px,
       0 0 0 0 inset;
   }
-
   25% {
     box-shadow:
       0 0 0 10px,


### PR DESCRIPTION
## What it does, and why

Avatar and Typography now use themeGet (when needed) and better usage of styled-system functions.

Note, the rgba value in Code was changed to simply warningLightest for ease of use/simplicity.