### PR TITLE
fix ref issue for TextInput and TextArea

### DIFF
--- a/packages/orcs-design-system/lib/components/TextArea/index.js
+++ b/packages/orcs-design-system/lib/components/TextArea/index.js
@@ -106,7 +106,7 @@ const Label = styled.label`
  * Specify size using `cols` and `rows` like shown in the example. adding `fullWidth` prop will override the cols value and make the text input 100% width of parent container.
  */
 
-export default function TextArea({ ...props }) {
+const TextArea = React.forwardRef((props, ref) => {
   const {
     inverted,
     id,
@@ -117,10 +117,6 @@ export default function TextArea({ ...props }) {
     mandatory,
     theme
   } = props;
-  const InputForward = React.forwardRef((props, ref) => (
-    <Input ref={ref} {...props} />
-  ));
-  const ref = React.createRef();
   return (
     <ThemeProvider theme={theme}>
       <Group fullWidth={fullWidth} {...props}>
@@ -133,11 +129,11 @@ export default function TextArea({ ...props }) {
         >
           {label}
         </Label>
-        <InputForward ref={ref} {...props} />
+        <Input ref={ref} {...props} />
       </Group>
     </ThemeProvider>
   );
-}
+});
 
 TextArea.propTypes = {
   /** Must be used to specify a unique ID. */
@@ -161,3 +157,5 @@ TextArea.propTypes = {
 TextArea.defaultProps = {
   theme: systemtheme
 };
+
+export default TextArea;

--- a/packages/orcs-design-system/lib/components/TextInput/index.js
+++ b/packages/orcs-design-system/lib/components/TextInput/index.js
@@ -1,5 +1,5 @@
-import NumberFormat from "react-number-format";
 import React from "react";
+import NumberFormat from "react-number-format";
 import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 import { space, layout } from "styled-system";
@@ -224,7 +224,7 @@ const Label = styled.label`
  *
  * Ensure to use a unique `id` for each input, and helpful placeholder text which shows an example of what should be input is very useful to users.
  */
-export default function TextInput({ ...props }) {
+const TextInput = React.forwardRef((props, ref) => {
   const {
     inverted,
     floating,
@@ -241,13 +241,13 @@ export default function TextInput({ ...props }) {
   // Strip numberProps from props for Input
   const { numberProps, ...rest } = props;
 
-  const NumberInputForward = React.forwardRef((props, ref) => (
-    <NumberInput ref={ref} {...rest} {...numberProps} />
-  ));
-  const InputForward = React.forwardRef((props, ref) => (
-    <Input ref={ref} {...rest} />
-  ));
-  const ref = React.createRef();
+  let getNumberInputRef = null;
+  if (numberProps && ref) {
+    getNumberInputRef = node => {
+      ref.current = node;
+    };
+  }
+
   return (
     <Group fullWidth={fullWidth} {...props}>
       {label && !floating ? (
@@ -262,9 +262,13 @@ export default function TextInput({ ...props }) {
         </Label>
       ) : null}
       {numberProps ? (
-        <NumberInputForward ref={ref} {...rest} {...numberProps} />
+        <NumberInput
+          getInputRef={getNumberInputRef}
+          {...rest}
+          {...numberProps}
+        />
       ) : (
-        <InputForward ref={ref} {...rest} />
+        <Input ref={ref} {...rest} />
       )}
       {label && floating ? (
         <Label
@@ -295,7 +299,7 @@ export default function TextInput({ ...props }) {
       ) : null}
     </Group>
   );
-}
+});
 
 TextInput.propTypes = {
   /** Must be used to specify a unique ID. */
@@ -325,3 +329,5 @@ TextInput.propTypes = {
   /** Set inverted styling for dark backgrounds */
   inverted: PropTypes.bool
 };
+
+export default TextInput;


### PR DESCRIPTION
## What it does, and why

> Add a thorough explanation of what the code in this PR does in this section.

Issue: In team list and people list page, when scroll to the bottom of the page, automatically loading more items, but the page is forced to scroll up.
Reason:
When Input re-rendered, the InputForwarded component is always re-created, which cause the input component to re-render and autoFocus set again.

ref should be passed from outside. and forwardRef should wrap the whole component.
Also, for NumberInput, it's using a special function getInputRef to return the ref, needs to handle that case.

## Checklist

> Please go through following checklist before requesting review and fix issues listed there. If your code touches the files with the below in question, please address them.

#### Workflow

- [ ] Are you writing documentation/comments for the bits of code with complex changes?
- [ ] Are you writing tests (Storybook/Unit testing)

## Jira Tickets

> If this PR implements changes related to one or more Jira tickets please add them here:

## UI Changes

> If this PR introduce some interaction or animation change please also add GIF with how it behaves. Don't forget that this change should be possible to simulate in storybook.
> You can use [this tool](http://gifbrewery.com/) to record your screen and convert it to a GIF.
