### PR TITLE
moves CNAME into storybook build

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-styleguide.orchestrated.io

--- a/packages/orcs-design-system/.storybook/static/CNAME
+++ b/packages/orcs-design-system/.storybook/static/CNAME
@@ -1,0 +1,1 @@
+styleguide.orchestrated.io

--- a/packages/orcs-design-system/package.json
+++ b/packages/orcs-design-system/package.json
@@ -17,7 +17,7 @@
     "deploy-stack": "serverless deploy",
     "deploy-client": "serverless client deploy  --no-confirm",
     "storybook": "start-storybook -s ./lib/assets",
-    "build-storybook": "build-storybook",
+    "build-storybook": "build-storybook -s .storybook/static",
     "deploy-storybook": "storybook-to-ghpages"
   },
   "dependencies": {


### PR DESCRIPTION
## What it does, and why

Moves CNAME for ghpages custom domain into storybook build. This is the correct process to ensure the custom domain is configured when storybook is deployed.

## Checklist

> Please go through following checklist before requesting review and fix issues listed there. If your code touches the files with the below in question, please address them.

#### Workflow

- [ ] Are you writing documentation/comments for the bits of code with complex changes?
- [ ] Are you writing tests (Storybook/Unit testing)

## Jira Tickets

> If this PR implements changes related to one or more Jira tickets please add them here:

## UI Changes

> If this PR introduce some interaction or animation change please also add GIF with how it behaves. Don't forget that this change should be possible to simulate in storybook.
> You can use [this tool](http://gifbrewery.com/) to record your screen and convert it to a GIF.
