### PR TITLE
fix: Chrome 83.0.4103.116 stopped the enter key default behaviour

### DIFF
--- a/packages/orcs-design-system/lib/components/Modal/index.js
+++ b/packages/orcs-design-system/lib/components/Modal/index.js
@@ -81,7 +81,7 @@ const Modal = props => {
       if (code === 13) {
         // 13 is the enter keycode
         onConfirm();
-        event.preventDefault();
+        // event.preventDefault();
       } else if (code === 27) {
         // 27 is the escape keycode
         onCancel();


### PR DESCRIPTION
in the modal keydown hanlder so Editor doesn't response to enter key, remove the preventDefault call

## What it does, and why

> Add a thorough explanation of what the code in this PR does in this section.

## Checklist

> Please go through following checklist before requesting review and fix issues listed there. If your code touches the files with the below in question, please address them.

#### Workflow

- [ ] Are you writing documentation/comments for the bits of code with complex changes?
- [ ] Are you writing tests (Storybook/Unit testing)

## Jira Tickets

> If this PR implements changes related to one or more Jira tickets please add them here:

## UI Changes

> If this PR introduce some interaction or animation change please also add GIF with how it behaves. Don't forget that this change should be possible to simulate in storybook.
> You can use [this tool](http://gifbrewery.com/) to record your screen and convert it to a GIF.
