### PR TITLE
MAPPER-1214 disable onclickoutside handler when modal is invisible

### DIFF
--- a/packages/orcs-design-system/lib/components/Modal/index.js
+++ b/packages/orcs-design-system/lib/components/Modal/index.js
@@ -159,9 +159,14 @@ const Modal = ({
   footerContent,
   ...restProps
 }) => {
-  const modalRef = useOnclickOutside(() => {
-    onClose();
-  });
+  const modalRef = useOnclickOutside(
+    () => {
+      onClose();
+    },
+    {
+      disabled: !visible
+    }
+  );
 
   useKeyPress(commonKeys.ESCAPE, onClose);
   useKeyPress(commonKeys.ESC, onClose);


### PR DESCRIPTION
## What it does, and why

> Add a thorough explanation of what the code in this PR does in this section.

The useOnclickOutside() hook will always add listeners to document to intercept mousedown event, which may cause issue.
Add a disabled flag when Modal is not visible.
This will stop useOnclickOutside add the event listeners.

## Checklist

> Please go through following checklist before requesting review and fix issues listed there. If your code touches the files with the below in question, please address them.

#### Workflow

- [ ] Are you writing documentation/comments for the bits of code with complex changes?
- [ ] Are you writing tests (Storybook/Unit testing)

## Jira Tickets

> If this PR implements changes related to one or more Jira tickets please add them here:

## UI Changes

> If this PR introduce some interaction or animation change please also add GIF with how it behaves. Don't forget that this change should be possible to simulate in storybook.
> You can use [this tool](http://gifbrewery.com/) to record your screen and convert it to a GIF.
