### PR TITLE
fix: only attach event listener when modal is visible

### DIFF
--- a/packages/orcs-design-system/lib/components/Modal/index.js
+++ b/packages/orcs-design-system/lib/components/Modal/index.js
@@ -159,17 +159,15 @@ const Modal = ({
   footerContent,
   ...restProps
 }) => {
-  const modalRef = useOnclickOutside(
-    () => {
-      onClose();
-    },
-    {
-      disabled: !visible
-    }
-  );
+  const options = {
+    disabled: !visible
+  };
+  const modalRef = useOnclickOutside(() => {
+    onClose();
+  }, options);
 
-  useKeyPress(commonKeys.ESCAPE, onClose);
-  useKeyPress(commonKeys.ESC, onClose);
+  useKeyPress(commonKeys.ESCAPE, onClose, options);
+  useKeyPress(commonKeys.ESC, onClose, options);
 
   return (
     <ThemeProvider theme={theme}>

--- a/packages/orcs-design-system/lib/hooks/keypress.js
+++ b/packages/orcs-design-system/lib/hooks/keypress.js
@@ -14,7 +14,7 @@ export const commonKeys = {
   ESCAPE: "Escape"
 };
 
-export const useKeyPress = (targetKey, callback) => {
+export const useKeyPress = (targetKey, callback, options = {}) => {
   // State for keeping track of whether key is pressed
   const [keyPressed, setKeyPressed] = useState(false);
 
@@ -36,13 +36,21 @@ export const useKeyPress = (targetKey, callback) => {
 
   // Add event listeners
   useEffect(() => {
-    window.addEventListener("keydown", downHandler);
-    window.addEventListener("keyup", upHandler);
-    // Remove event listeners on cleanup
-    return () => {
+    const removeEventListeners = () => {
       window.removeEventListener("keydown", downHandler);
       window.removeEventListener("keyup", upHandler);
     };
+
+    if (options.disabled) {
+      removeEventListeners();
+      return;
+    }
+
+    window.addEventListener("keydown", downHandler);
+    window.addEventListener("keyup", upHandler);
+
+    // Remove event listeners on cleanup
+    return removeEventListeners;
   });
 
   return keyPressed;


### PR DESCRIPTION
## What it does, and why

> Add a thorough explanation of what the code in this PR does in this section.

The keydown and keyup event handlers is always attached if Modal is rendered.
This causes several modal close events are triggered if ESC is pressed.

## Checklist

> Please go through following checklist before requesting review and fix issues listed there. If your code touches the files with the below in question, please address them.

#### Workflow

- [ ] Are you writing documentation/comments for the bits of code with complex changes?
- [ ] Are you writing tests (Storybook/Unit testing)

## Jira Tickets

> If this PR implements changes related to one or more Jira tickets please add them here:

## UI Changes

> If this PR introduce some interaction or animation change please also add GIF with how it behaves. Don't forget that this change should be possible to simulate in storybook.
> You can use [this tool](http://gifbrewery.com/) to record your screen and convert it to a GIF.
